### PR TITLE
fix: respect user styling option and not show `createWallet` or `SetUpNewDevice` modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@paperxyz/embedded-wallet-service-sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@paperxyz/embedded-wallet-service-sdk",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@ethersproject/abstract-signer": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@paperxyz/embedded-wallet-service-sdk",
   "description": "Paper.xyz sdk for embedded wallets",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "files": [
     "dist/**/*"
   ],

--- a/src/interfaces/EmbeddedWallets/EmbeddedWallets.ts
+++ b/src/interfaces/EmbeddedWallets/EmbeddedWallets.ts
@@ -1,12 +1,20 @@
-import { EmbeddedWallet } from "../../lib/EmbeddedWallets/EmbeddedWallet";
+import type { EmbeddedWallet } from "../../lib/EmbeddedWallets/EmbeddedWallet";
+import type { EmbeddedWalletIframeCommunicator } from "../../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 import { CustomizationOptionsType } from "../utils/IframeCommunicator";
 
 // General Embedded wallet types
 export type Chains = "Polygon" | "Mumbai" | "Goerli" | "Ethereum";
 
 // Class constructor types
-export type PaperBaseConstructorType = { clientId: string; chain: Chains };
-export type PaperConstructorWithStylesType = PaperBaseConstructorType & {
+export type ClientIdConstructorType = { clientId: string };
+export type ClientIdWithQuerierType = ClientIdConstructorType & {
+  querier: EmbeddedWalletIframeCommunicator<any>;
+};
+export type ClientIdWithQuerierAndChainType = ClientIdWithQuerierType & {
+  chain: Chains;
+};
+export type PaperConstructorType = ClientIdConstructorType & {
+  chain: Chains;
   styles?: CustomizationOptionsType;
 };
 

--- a/src/interfaces/EmbeddedWallets/EmbeddedWallets.ts
+++ b/src/interfaces/EmbeddedWallets/EmbeddedWallets.ts
@@ -38,6 +38,7 @@ export type LogoutReturnType = { success: boolean };
 export type GetAuthDetailsReturnType = { authDetails?: AuthDetails };
 
 // TODO: Maybe consolidate types
+// this is the return type from the iframe
 export type GetUserStatusReturnType =
   | {
       status: UserStatus.LOGGED_OUT;
@@ -55,6 +56,8 @@ export type GetUserStatusReturnType =
       status: UserStatus.LOGGED_IN_WALLET_INITIALIZED;
       data: Omit<InitializedUser, "wallet">;
     };
+
+// this is the return type from the function that user calls
 export type GetUserStatusType =
   | {
       status: UserStatus.LOGGED_OUT;

--- a/src/interfaces/EmbeddedWallets/EmbeddedWallets.ts
+++ b/src/interfaces/EmbeddedWallets/EmbeddedWallets.ts
@@ -6,6 +6,7 @@ import { CustomizationOptionsType } from "../utils/IframeCommunicator";
 export type Chains = "Polygon" | "Mumbai" | "Goerli" | "Ethereum";
 
 // Class constructor types
+// TODO: Probably clean this up eventually
 export type ClientIdConstructorType = { clientId: string };
 export type ClientIdWithQuerierType = ClientIdConstructorType & {
   querier: EmbeddedWalletIframeCommunicator<any>;

--- a/src/lib/Auth.ts
+++ b/src/lib/Auth.ts
@@ -6,15 +6,15 @@ import {
   GetSocialLoginClientIdReturnType,
 } from "../interfaces/Auth";
 import type {
+  ClientIdWithQuerierType,
   LogoutReturnType,
-  PaperConstructorWithStylesType,
 } from "../interfaces/EmbeddedWallets/EmbeddedWallets";
 import { CustomizationOptionsType } from "../interfaces/utils/IframeCommunicator";
 import { EmbeddedWalletIframeCommunicator } from "../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 import { LocalStorage } from "../utils/Storage/LocalStorage";
 import { openModalForFunction } from "./Modal/Modal";
 
-export type AuthTypes = {
+export type AuthQuerierTypes = {
   loginWithJwtAuthCallback: {
     token: string;
     authProvider: AuthProvider;
@@ -34,8 +34,9 @@ export type AuthTypes = {
 
 export class Auth {
   protected clientId: string;
+  // TODO: Remove once we deprecate other login methods
   protected styles: CustomizationOptionsType | undefined;
-  protected AuthQuerier: EmbeddedWalletIframeCommunicator<AuthTypes>;
+  protected AuthQuerier: EmbeddedWalletIframeCommunicator<AuthQuerierTypes>;
   protected localStorage: LocalStorage;
 
   /**
@@ -48,12 +49,13 @@ export class Auth {
   constructor({
     clientId,
     styles,
-  }: Omit<PaperConstructorWithStylesType, "chain">) {
+    querier,
+  }: ClientIdWithQuerierType & {
+    styles?: CustomizationOptionsType;
+  }) {
     this.clientId = clientId;
     this.styles = styles;
-    this.AuthQuerier = new EmbeddedWalletIframeCommunicator({
-      clientId,
-    });
+    this.AuthQuerier = querier;
     this.localStorage = new LocalStorage({ clientId });
   }
 

--- a/src/lib/EmbeddedWallets/EmbeddedWallet.ts
+++ b/src/lib/EmbeddedWallets/EmbeddedWallet.ts
@@ -29,11 +29,7 @@ export type WalletManagementUiTypes = {
   setUpNewDeviceUi: void;
 };
 
-export type EmbeddedWalletInternalHelperType =
-  | { showUi: false; recoveryPassword?: string }
-  | {
-      showUi: true;
-    };
+export type EmbeddedWalletInternalHelperType = { showUi: boolean };
 
 export class EmbeddedWallet {
   protected clientId: string;

--- a/src/lib/EmbeddedWallets/EmbeddedWallet.ts
+++ b/src/lib/EmbeddedWallets/EmbeddedWallet.ts
@@ -19,8 +19,8 @@ import { GaslessTransactionMaker } from "./GaslessTransactionMaker";
 import { EthersSigner } from "./Signer";
 
 export type WalletManagementTypes = {
-  createWallet: void | { recoveryPassword: string };
-  setUpNewDevice: void | { recoveryPassword: string };
+  createWallet: void;
+  setUpNewDevice: void;
   getUserStatus: void;
   saveDeviceShare: { deviceShareStored: string };
 };

--- a/src/lib/EmbeddedWallets/EmbeddedWallet.ts
+++ b/src/lib/EmbeddedWallets/EmbeddedWallet.ts
@@ -18,7 +18,7 @@ import { GaslessTransactionMaker } from "./GaslessTransactionMaker";
 import { EthersSigner } from "./Signer";
 
 export type WalletManagementTypes = {
-  createWallet: { recoveryPassword: string };
+  createWallet: void;
   setUpNewDevice: { recoveryPassword: string };
   createWalletUi: void;
   setUpNewDeviceUi: void;
@@ -86,26 +86,12 @@ export class EmbeddedWallet {
    * * pwd >= 6 character
    * @returns {{walletAddress: string}} an object containing the user's wallet address
    */
-  private async createWallet(
-    props: EmbeddedWalletInternalHelperType
-  ): Promise<SetUpWalletReturnType | undefined> {
-    let newWalletDetails: SetUpWalletRpcReturnType;
-    if (props.showUi) {
-      newWalletDetails =
-        await this.walletManagerQuerier.call<SetUpWalletRpcReturnType>({
-          procedureName: "createWalletUi",
-          params: undefined,
-          showIframe: true,
-        });
-    } else {
-      newWalletDetails =
-        await this.walletManagerQuerier.call<SetUpWalletRpcReturnType>({
-          procedureName: "createWallet",
-          params: {
-            recoveryPassword: props.recoveryPassword,
-          },
-        });
-    }
+  private async createWallet(): Promise<SetUpWalletReturnType | undefined> {
+    const newWalletDetails =
+      await this.walletManagerQuerier.call<SetUpWalletRpcReturnType>({
+        procedureName: "createWallet",
+        params: undefined,
+      });
     await this.postSetUpWallet(newWalletDetails);
 
     return {
@@ -182,10 +168,7 @@ export class EmbeddedWallet {
         });
       }
       case UserStatus.LOGGED_IN_WALLET_UNINITIALIZED: {
-        return this.createWallet({
-          showUi: true,
-          ...this.styles,
-        });
+        return this.createWallet();
       }
       case UserStatus.LOGGED_OUT: {
         return;

--- a/src/lib/EmbeddedWallets/EmbeddedWallet.ts
+++ b/src/lib/EmbeddedWallets/EmbeddedWallet.ts
@@ -90,12 +90,13 @@ export class EmbeddedWallet {
         await this.walletManagerQuerier.call<SetUpWalletRpcReturnType>({
           procedureName: "createWalletUi",
           params: undefined,
+          showIframe: true,
         });
     } else {
       newWalletDetails =
         await this.walletManagerQuerier.call<SetUpWalletRpcReturnType>({
           procedureName: "createWallet",
-          params:undefined
+          params: undefined,
         });
     }
     await this.postSetUpWallet(newWalletDetails);

--- a/src/lib/EmbeddedWallets/GaslessTransactionMaker.ts
+++ b/src/lib/EmbeddedWallets/GaslessTransactionMaker.ts
@@ -1,12 +1,12 @@
 import type {
   Chains,
-  PaperBaseConstructorType,
+  ClientIdWithQuerierAndChainType,
 } from "../../interfaces/EmbeddedWallets/EmbeddedWallets";
 import type {
   CallContractReturnType,
   ContractCallInputType,
 } from "../../interfaces/EmbeddedWallets/GaslessTransactionMaker";
-import { EmbeddedWalletIframeCommunicator } from "../../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
+import type { EmbeddedWalletIframeCommunicator } from "../../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 
 export type GaslessTransactionQuerierTypes = {
   callContract: {
@@ -26,12 +26,10 @@ export class GaslessTransactionMaker {
   protected chain: Chains;
   protected clientId: string;
   protected gaslessTransactionQuerier: EmbeddedWalletIframeCommunicator<GaslessTransactionQuerierTypes>;
-  constructor({ chain, clientId }: PaperBaseConstructorType) {
+  constructor({ chain, clientId, querier }: ClientIdWithQuerierAndChainType) {
     this.chain = chain;
     this.clientId = clientId;
-    this.gaslessTransactionQuerier = new EmbeddedWalletIframeCommunicator({
-      clientId,
-    });
+    this.gaslessTransactionQuerier = querier;
   }
   /**
    * @description

--- a/src/lib/EmbeddedWallets/Signer.ts
+++ b/src/lib/EmbeddedWallets/Signer.ts
@@ -6,6 +6,7 @@ import { Signer } from "@ethersproject/abstract-signer";
 import type { Bytes } from "@ethersproject/bytes";
 import type { Deferrable } from "@ethersproject/properties";
 import { defineReadOnly } from "@ethersproject/properties";
+import { ClientIdWithQuerierType } from "../../interfaces/EmbeddedWallets/EmbeddedWallets";
 import type {
   GetAddressReturnType,
   SignMessageReturnType,
@@ -30,13 +31,13 @@ export class EthersSigner extends Signer {
   constructor({
     provider,
     clientId,
-  }: {
+    querier,
+  }: ClientIdWithQuerierType & {
     provider: Provider;
-    clientId: string;
   }) {
     super();
     this.clientId = clientId;
-    this.querier = new EmbeddedWalletIframeCommunicator({ clientId });
+    this.querier = querier;
     defineReadOnly(this, "provider", provider);
   }
 
@@ -81,6 +82,7 @@ export class EthersSigner extends Signer {
     return new EthersSigner({
       clientId: this.clientId,
       provider,
+      querier: this.querier,
     });
   }
 }

--- a/src/lib/EmbeddedWallets/WalletHoldings.ts
+++ b/src/lib/EmbeddedWallets/WalletHoldings.ts
@@ -1,6 +1,6 @@
 import {
   Chains,
-  PaperBaseConstructorType,
+  ClientIdWithQuerierAndChainType,
 } from "../../interfaces/EmbeddedWallets/EmbeddedWallets";
 import {
   WalletHoldingInputType,
@@ -17,16 +17,15 @@ export type WalletHoldingQueryTypes = {
  * @description WalletHoldings responsible for all the read related methods that the developers might want to do with EmbeddedWallet
  */
 export class WalletHoldings {
-  protected clientId: string;
   protected chain: Chains;
   protected walletHoldingQuerier: EmbeddedWalletIframeCommunicator<WalletHoldingQueryTypes>;
 
-  constructor({ chain, clientId }: PaperBaseConstructorType) {
-    this.clientId = clientId;
+  constructor({
+    chain,
+    querier,
+  }: Omit<ClientIdWithQuerierAndChainType, "clientId">) {
     this.chain = chain;
-    this.walletHoldingQuerier = new EmbeddedWalletIframeCommunicator({
-      clientId,
-    });
+    this.walletHoldingQuerier = querier;
   }
   // TODO: limit and offset are not currently being respected because they are not supported by simple-hash
   async listNfts({ chain, limit, offset }: WalletHoldingInputType) {

--- a/src/lib/Paper.ts
+++ b/src/lib/Paper.ts
@@ -1,14 +1,16 @@
 import type {
   GetUserStatusType,
   InitializedUser,
-  PaperConstructorWithStylesType,
+  PaperConstructorType,
 } from "../interfaces/EmbeddedWallets/EmbeddedWallets";
 import { UserStatus } from "../interfaces/EmbeddedWallets/EmbeddedWallets";
+import { EmbeddedWalletIframeCommunicator } from "../utils/iFrameCommunication/EmbeddedWalletIframeCommunicator";
 import { Auth } from "./Auth";
 import { EmbeddedWallet } from "./EmbeddedWallets/EmbeddedWallet";
 
 export class PaperEmbeddedWalletSdk {
   protected clientId: string;
+  protected querier: EmbeddedWalletIframeCommunicator<any>;
 
   private wallet: EmbeddedWallet;
   /**
@@ -23,14 +25,18 @@ export class PaperEmbeddedWalletSdk {
    * @param {Chains} initParams.chain sets the default chain that the EmbeddedWallet will live on.
    * @param {CustomizationOptionsType} initParams.styles sets the default style override for any modal that pops up asking for user's details when creating wallet or logging in.
    */
-  constructor({ clientId, chain, styles }: PaperConstructorWithStylesType) {
+  constructor({ clientId, chain, styles }: PaperConstructorType) {
     this.clientId = clientId;
-    this.auth = new Auth({ clientId, styles });
+    this.querier = new EmbeddedWalletIframeCommunicator({
+      clientId,
+      customizationOptions: styles,
+    });
+    this.auth = new Auth({ clientId, styles, querier: this.querier });
 
     this.wallet = new EmbeddedWallet({
       clientId,
       chain,
-      styles,
+      querier: this.querier,
     });
   }
 

--- a/src/utils/iFrameCommunication/EmbeddedWalletIframeCommunicator.ts
+++ b/src/utils/iFrameCommunication/EmbeddedWalletIframeCommunicator.ts
@@ -1,4 +1,5 @@
 import { EMBEDDED_WALLET_PATH, PAPER_APP_URL } from "../../constants/settings";
+import { CustomizationOptionsType } from "../../interfaces/utils/IframeCommunicator";
 import { LocalStorage } from "../Storage/LocalStorage";
 import { IframeCommunicator } from "./IframeCommunicator";
 
@@ -6,12 +7,19 @@ export class EmbeddedWalletIframeCommunicator<
   T extends { [key: string]: any }
 > extends IframeCommunicator<T> {
   protected clientId: string;
-  constructor({ clientId }: { clientId: string }) {
+  constructor({
+    clientId,
+    customizationOptions,
+  }: {
+    clientId: string;
+    customizationOptions?: CustomizationOptionsType;
+  }) {
     super({
       iframeId: EMBEDDED_WALLET_IFRAME_ID,
       link: createEmbeddedWalletIframeLink({
         clientId,
         path: EMBEDDED_WALLET_PATH,
+        queryParams: customizationOptions,
       }).href,
       container: document.body,
     });

--- a/src/utils/iFrameCommunication/IframeCommunicator.ts
+++ b/src/utils/iFrameCommunication/IframeCommunicator.ts
@@ -33,7 +33,6 @@ export class IframeCommunicator<T extends { [key: string]: any }> {
   }: IFrameCommunicatorProps) {
     // Creating the IFrame element for communication
     let iframe = document.getElementById(iframeId) as HTMLIFrameElement | null;
-
     if (!iframe || iframe.src != link) {
       if (!iframe) {
         iframe = document.createElement("iframe");


### PR DESCRIPTION
refactor: move iframeCommunicator to composition pattern (so that it's easier to respect styling)
refactor(createWallet): update embedded wallet internal API to not show modals by default