### PR TITLE
Add GitHub Contributing Guide and Security Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+## Contributing
+
+In your PR, if you want to release a new SDK version base on the current PR, run `npm run changeset` and answer the prompts.
+
+This will generate file(s) in the `.changeset` folder. Commit those.
+
+Upon merge, and new PR will be opened by the changeset bot to track the changes and prepare the SDK for release.
+
+Once you're ready for release, simply merge the `Version Packages` PR and the bot will handle maintaining a changelog, building the SDK, and releasing it to NPM.
+
+### Reporting a security issue
+
+Please review our [security policy](SECURITY.md) for more details.

--- a/README.md
+++ b/README.md
@@ -48,10 +48,4 @@ const { transactionHash } = await user.wallet.gasless.callContract({
 
 ## Contributing
 
-In your PR, if you want to release a new SDK version base on the current PR, run `npm run changeset` and answer the prompts.
-
-This will generate file(s) in the `.changeset` folder. Commit those.
-
-Upon merge, and new PR will be opened by the changeset bot to track the changes and prepare the SDK for release.
-
-Once you're ready for release, simply merge the `Version Packages` PR and the bot will handle maintaining a changelog, building the SDK, and releasing it to NPM.
+Please review our guidelines(CONTRIBUTING.md) for more details.

--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ const { transactionHash } = await user.wallet.gasless.callContract({
 
 ## Contributing
 
-Please review our guidelines(CONTRIBUTING.md) for more details.
+Please review our [guidelines](CONTRIBUTING.md) for more details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+## Security
+Paper takes the security of our software products and services seriously, which includes all source code repositories managed through our GitHub organizations, which include [Paper Embedded wallet Service SDK](https://github.com/paperxyz/embedded-wallet-service-sdk) and [many others](https://github.com/paperxyz).
+
+If you believe you have found a security vulnerability in any Paper-owned repository please report it to us as described below.
+
+## Reporting Security Issues
+**Please do not report security vulnerabilities through public GitHub issues.** Instead, please report them to [support@withpaper.com](support@withpaper.com).
+
+You should receive a prompt response. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+  * Type of issue (e.g. missing encryption of sensitive data, SQL injection, cross-site scripting, etc.)
+  * Full paths of source file(s) related to the manifestation of the issue
+  * The location of the affected source code (tag/branch/commit or direct URL)
+  * Any special configuration required to reproduce the issue
+  * Step-by-step instructions to reproduce the issue
+  * Proof-of-concept or exploit code (if possible)
+  * Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+ 
+## Preferred Languages
+We prefer all communications to be in English.


### PR DESCRIPTION
This adds a contributing guide and security policy to the embedded wallet service SDK.

**This update bears no changes to the SDK's features and functionality.**

## Benefits
Adding a security policy will enable the **Security Policy** option under the **Security** tab in GitHub.
<img width="987" alt="image" src="https://user-images.githubusercontent.com/34169713/222895539-be9de29f-ee68-4fd7-9fb9-a7845f36689e.png">

It will also prompt new contributors in GitHub to review the repository's **contributing guidelines** when reporting a GitHub Issue or opening a pull request for the first time.
<img width="1284" alt="image" src="https://user-images.githubusercontent.com/34169713/222895616-37fb8219-6230-4c0b-ae8b-f0396645056a.png">
